### PR TITLE
Restore private messages button

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -11,6 +11,18 @@
         </h2>
       <% end %>
 
+      <% if @user != current_user %>
+        <% if @user.email_on_direct_message? %>
+        <%= link_to t("users.show.send_private_message"),
+            new_user_direct_message_path(@user),
+            class: "button hollow float-right" %>
+        <% else %>
+          <div class="callout primary float-right">
+            <%= t("users.show.no_private_messages") %>
+          </div>
+        <% end %>
+      <% end %>
+
       <% if @user.public_activity || @authorized_current_user %>
         <ul class="menu simple margin-top">
           <% @valid_filters.each do |filter| %>


### PR DESCRIPTION
Restores the button that allows private messages.

Requires a minor edit on the Rails console to proceed.

```ruby
Setting['direct_message_max_per_day'] = 5
```