### PR TITLE
Notify supporters and comments on edit

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -25,7 +25,7 @@ class AccountController < ApplicationController
       if @account.organization?
         params.require(:account).permit(:phone_number, :email_on_comment, :email_on_comment_reply, :newsletter, organization_attributes: [:name, :responsible_name])
       else
-        params.require(:account).permit(:username, :public_activity, :email_on_comment, :email_on_comment_reply, :email_on_direct_message, :email_digest, :newsletter, :official_position_badge)
+        params.require(:account).permit(:username, :public_activity, :email_on_comment, :email_on_comment_reply, :email_on_direct_message, :email_digest, :newsletter, :official_position_badge, :email_on_proposal_edit, :email_on_proposal_edit_as_commenter)
       end
     end
 

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -35,6 +35,10 @@ class ProposalsController < ApplicationController
   def update
     super
     ProposalNotifier.new(proposal: @proposal).process
+
+    @proposal.voters.each do |voter|
+      Notification.add(voter.id, @proposal) unless voter == @proposal.author
+    end
   end
 
   def index_customization

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -34,10 +34,11 @@ class ProposalsController < ApplicationController
 
   def update
     super
+
     ProposalNotifier.new(proposal: @proposal).process
 
     @proposal.voters.each do |voter|
-      Notification.add(voter.id, @proposal) unless voter == @proposal.author
+      Notification.add(voter.id, @proposal) unless voter.id == @proposal.author.id
     end
   end
 

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -32,6 +32,11 @@ class ProposalsController < ApplicationController
     redirect_to proposal_path(@proposal), status: :moved_permanently if request.path != proposal_path(@proposal)
   end
 
+  def update
+    super
+    CommentNotifier.new(comment: @proposal).process
+  end
+
   def index_customization
     discard_archived
     load_retired

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -34,7 +34,7 @@ class ProposalsController < ApplicationController
 
   def update
     super
-    CommentNotifier.new(comment: @proposal).process
+    ProposalNotifier.new(proposal: @proposal).process
   end
 
   def index_customization

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -38,7 +38,7 @@ class ProposalsController < ApplicationController
     ProposalNotifier.new(proposal: @proposal).process
 
     @proposal.voters.each do |voter|
-      Notification.add(voter.id, @proposal) unless voter.id == @proposal.author.id
+      Notification.add(voter.id, @proposal.versions.last) unless voter.id == @proposal.author.id
     end
   end
 

--- a/app/mailers/proposal_mailer.rb
+++ b/app/mailers/proposal_mailer.rb
@@ -6,10 +6,12 @@ class ProposalMailer < ApplicationMailer
   def edit(proposal)
     @proposal = proposal
     @voters = proposal.voters
+    @last_version = proposal.versions.last.reify
 
     @voters.each  do | voter |
       with_user(voter) do
-        mail(to: voter.email, subject: 'Test')
+        @voter = voter
+        mail(to: voter.email, subject: "Proposal #{@last_version.title} you supported has been changed")
       end
     end
   end

--- a/app/mailers/proposal_mailer.rb
+++ b/app/mailers/proposal_mailer.rb
@@ -1,0 +1,24 @@
+class ProposalMailer < ApplicationMailer
+  helper :text_with_links
+  helper :mailer
+  helper :users
+
+  def edit(proposal)
+    @proposal = proposal
+    @voters = proposal.voters
+
+    @voters.each  do | voter |
+      with_user(voter) do
+        mail(to: voter.email, subject: 'Test')
+      end
+    end
+  end
+
+  private
+
+  def with_user(user, &block)
+    I18n.with_locale(user.locale) do
+      block.call
+    end
+  end
+end

--- a/app/mailers/proposal_mailer.rb
+++ b/app/mailers/proposal_mailer.rb
@@ -3,13 +3,16 @@ class ProposalMailer < ApplicationMailer
   helper :mailer
   helper :users
 
-  def edit(voter, proposal)
+  def edit(voter, proposal, is_comment = false)
     @proposal = proposal
     @last_version = proposal.versions.last.reify
     @voter = voter
+    @is_comment = is_comment
+
+    subject = @is_comment ? "Proposal #{@last_version.title} you commented on has been changed" : "Proposal #{@last_version.title} you supported has been changed"
 
     with_user(@voter) do
-      mail(to: voter.email, subject: "Proposal #{@last_version.title} you supported has been changed")
+      mail(to: voter.email, subject: subject)
     end
   end
 

--- a/app/mailers/proposal_mailer.rb
+++ b/app/mailers/proposal_mailer.rb
@@ -3,19 +3,14 @@ class ProposalMailer < ApplicationMailer
   helper :mailer
   helper :users
 
-  def edit(proposal)
+  def edit(voter, proposal)
     @proposal = proposal
     @last_version = proposal.versions.last.reify
-    voters = proposal.voters
+    @voter = voter
 
-    voters.each  do | voter |
-      with_user(voter) do
-        @voter = voter
-        mail(to: voter.email, subject: "Proposal #{@last_version.title} you supported has been changed")
-      end
+    with_user(@voter) do
+      mail(to: voter.email, subject: "Proposal #{@last_version.title} you supported has been changed")
     end
-
-    unique_commenters = proposal.comments.collect(&:author).uniq{|author| author.id}
   end
 
   private

--- a/app/mailers/proposal_mailer.rb
+++ b/app/mailers/proposal_mailer.rb
@@ -5,15 +5,17 @@ class ProposalMailer < ApplicationMailer
 
   def edit(proposal)
     @proposal = proposal
-    @voters = proposal.voters
     @last_version = proposal.versions.last.reify
+    voters = proposal.voters
 
-    @voters.each  do | voter |
+    voters.each  do | voter |
       with_user(voter) do
         @voter = voter
         mail(to: voter.email, subject: "Proposal #{@last_version.title} you supported has been changed")
       end
     end
+
+    unique_commenters = proposal.comments.collect(&:author).uniq{|author| author.id}
   end
 
   private

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -30,6 +30,8 @@ class Notification < ActiveRecord::Base
       notifiable.proposal.title
     when "Proposal"
       notifiable.title
+    when "PaperTrail::Version"
+      notifiable.item.title
     when "Comment"
       notifiable.commentable.title
     else
@@ -41,7 +43,7 @@ class Notification < ActiveRecord::Base
     case notifiable_type
     when "ProposalNotification"
       "proposal_notification"
-    when "Proposal"
+    when "PaperTrail::Version"
       "edited"
     when "Comment"
       "replies_to"
@@ -51,6 +53,12 @@ class Notification < ActiveRecord::Base
   end
 
   def linkable_resource
-    notifiable.is_a?(ProposalNotification) ? notifiable.proposal : notifiable
+    if notifiable.is_a?(ProposalNotification)
+      notifiable.proposal
+    elsif notifiable.is_a?(PaperTrail::Version)
+      notifiable.item
+    else
+      notifiable
+    end
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -28,6 +28,8 @@ class Notification < ActiveRecord::Base
     case notifiable.class.name
     when "ProposalNotification"
       notifiable.proposal.title
+    when "Proposal"
+      notifiable.title
     when "Comment"
       notifiable.commentable.title
     else
@@ -39,6 +41,8 @@ class Notification < ActiveRecord::Base
     case notifiable_type
     when "ProposalNotification"
       "proposal_notification"
+    when "Proposal"
+      "edited"
     when "Comment"
       "replies_to"
     else

--- a/app/models/proposal_notifier.rb
+++ b/app/models/proposal_notifier.rb
@@ -15,25 +15,23 @@ class ProposalNotifier
     unique_commenters = @proposal.comments.collect(&:author).uniq{|author| author.id}
 
     unique_commenters.each do | commenter |
-      if @proposal.author.id == commenter.id
-        next
-      end
-
+      @commenter = commenter
       ProposalMailer.edit(commenter, @proposal).deliver_later if email_on_comment?
     end
   end
 
   def send_email_to_supporters
     @proposal.voters.each  do | voter |
-      ProposalMailer.edit(voter, @proposal).deliver_later if email_on_edit?
+      @current_voter = voter
+      ProposalMailer.edit(@current_voter, @proposal).deliver_later if email_on_edit?
     end
   end
 
   def email_on_edit?
-    true
+    @current_voter.email_on_proposal_edit?
   end
 
   def email_on_comment?
-    true
+    @author != @commenter && @commenter.email_on_proposal_edit_as_commenter?
   end
 end

--- a/app/models/proposal_notifier.rb
+++ b/app/models/proposal_notifier.rb
@@ -16,7 +16,7 @@ class ProposalNotifier
 
     unique_commenters.each do | commenter |
       @commenter = commenter
-      ProposalMailer.edit(commenter, @proposal).deliver_later if email_on_comment?
+      ProposalMailer.edit(commenter, @proposal, true).deliver_later if email_on_comment?
     end
   end
 
@@ -28,10 +28,12 @@ class ProposalNotifier
   end
 
   def email_on_edit?
-    @current_voter.email_on_proposal_edit?
+    @current_voter.email_on_proposal_edit? && @current_voter != @author
   end
 
   def email_on_comment?
+    # If the commenter is also a supporter, don't email them.
+
     @author != @commenter && @commenter.email_on_proposal_edit_as_commenter?
   end
 end

--- a/app/models/proposal_notifier.rb
+++ b/app/models/proposal_notifier.rb
@@ -32,7 +32,7 @@ class ProposalNotifier
   end
 
   def email_on_comment?
-    # If the commenter is also a supporter, don't email them.
+    return false if proposal.voters.include? @commenter
 
     @author != @commenter && @commenter.email_on_proposal_edit_as_commenter?
   end

--- a/app/models/proposal_notifier.rb
+++ b/app/models/proposal_notifier.rb
@@ -1,0 +1,29 @@
+class ProposalNotifier
+  def initialize(args = {})
+    @proposal = args.fetch(:proposal)
+    @author  = @proposal.author
+  end
+
+  def process
+    send_email_to_supporters
+  end
+
+  private
+
+  def send_email_to_supporters
+    ProposalMailer.edit(@proposal).deliver_later
+    # ProposalMailer.edit(@proposal).deliver_later if email_on_comment?
+  end
+
+  def email_on_comment?
+    commentable_author = @comment.commentable.author
+    commentable_author != @author && commentable_author.email_on_comment?
+  end
+
+  def email_on_comment_reply?
+    return false unless @comment.reply?
+    parent_author = @comment.parent.author
+    parent_author != @author && parent_author.email_on_comment_reply?
+  end
+
+end

--- a/app/models/proposal_notifier.rb
+++ b/app/models/proposal_notifier.rb
@@ -15,7 +15,9 @@ class ProposalNotifier
   end
 
   def send_email_to_supporters
-    ProposalMailer.edit(@proposal).deliver_later if email_on_edit?
+    @proposal.voters.each  do | voter |
+      ProposalMailer.edit(voter, @proposal).deliver_later if email_on_edit?
+    end
   end
 
   def email_on_edit?

--- a/app/models/proposal_notifier.rb
+++ b/app/models/proposal_notifier.rb
@@ -32,7 +32,7 @@ class ProposalNotifier
   end
 
   def email_on_comment?
-    return false if proposal.voters.include? @commenter
+    return false if @proposal.voters.include? @commenter
 
     @author != @commenter && @commenter.email_on_proposal_edit_as_commenter?
   end

--- a/app/models/proposal_notifier.rb
+++ b/app/models/proposal_notifier.rb
@@ -12,6 +12,15 @@ class ProposalNotifier
   private
 
   def send_email_to_commenters
+    unique_commenters = @proposal.comments.collect(&:author).uniq{|author| author.id}
+
+    unique_commenters.each do | commenter |
+      if @proposal.author.id == commenter.id
+        next
+      end
+
+      ProposalMailer.edit(commenter, @proposal).deliver_later if email_on_comment?
+    end
   end
 
   def send_email_to_supporters
@@ -24,4 +33,7 @@ class ProposalNotifier
     true
   end
 
+  def email_on_comment?
+    true
+  end
 end

--- a/app/models/proposal_notifier.rb
+++ b/app/models/proposal_notifier.rb
@@ -6,24 +6,20 @@ class ProposalNotifier
 
   def process
     send_email_to_supporters
+    send_email_to_commenters
   end
 
   private
 
+  def send_email_to_commenters
+  end
+
   def send_email_to_supporters
-    ProposalMailer.edit(@proposal).deliver_later
-    # ProposalMailer.edit(@proposal).deliver_later if email_on_comment?
+    ProposalMailer.edit(@proposal).deliver_later if email_on_edit?
   end
 
-  def email_on_comment?
-    commentable_author = @comment.commentable.author
-    commentable_author != @author && commentable_author.email_on_comment?
-  end
-
-  def email_on_comment_reply?
-    return false unless @comment.reply?
-    parent_author = @comment.parent.author
-    parent_author != @author && parent_author.email_on_comment_reply?
+  def email_on_edit?
+    true
   end
 
 end

--- a/app/views/account/show.html.erb
+++ b/app/views/account/show.html.erb
@@ -85,6 +85,24 @@
             <% end %>
           </div>
 
+          <div>
+            <%= f.label :email_on_proposal_edit do %>
+              <%= f.check_box :email_on_proposal_edit, title: t('account.show.email_on_proposal_edit_label'), label: false %>
+              <span class="checkbox">
+                <%= t("account.show.email_on_proposal_edit_label") %>
+              </span>
+            <% end %>
+          </div>
+
+          <div>
+            <%= f.label :email_on_proposal_edit_as_commenter do %>
+              <%= f.check_box :email_on_proposal_edit_as_commenter, title: t('account.show.email_on_proposal_edit_as_commenter_label'), label: false %>
+              <span class="checkbox">
+                <%= t("account.show.email_on_proposal_edit_as_commenter_label") %>
+              </span>
+            <% end %>
+          </div>
+
           <% if @account.official_level == 1 %>
             <div>
               <%= f.label :official_position_badge do %>

--- a/app/views/proposal_mailer/edit.html.erb
+++ b/app/views/proposal_mailer/edit.html.erb
@@ -1,0 +1,22 @@
+<td style="padding-bottom: 20px; padding-left: 10px;">
+
+  <h1 style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;">
+    <%= t("mailers.comment.title") %>
+  </h1>
+
+  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
+    <%= t("mailers.comment.hi") %> <strong><%= @commentable.author.name %></strong>,
+  </p>
+
+  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
+    <%= t("mailers.comment.new_comment_by_html", commenter: @comment.author.name) %> <%= link_to @commentable.title, commentable_url(@commentable), style: "color: #2895F1; text-decoration:none;" %>
+  </p>
+
+  <p style="border-left: 2px solid #DEE0E3;font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-style: italic;font-weight: normal;line-height: 24px;margin-left: 20px;padding: 10px;">
+    <%= text_with_links @comment.body %>
+  </p>
+
+  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 12px;font-weight: normal;line-height: 20px;">
+    <%= t("mailers.config.manage_email_subscriptions") %> <%= link_to t("account.show.title"), account_url, style: "color: #2895F1; text-decoration:none;" %>
+  </p>
+</td>

--- a/app/views/proposal_mailer/edit.html.erb
+++ b/app/views/proposal_mailer/edit.html.erb
@@ -10,12 +10,21 @@
 
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
     <%= t("mailers.proposal.edit.introduction", title: @proposal.title) %>
-    <%= t("mailers.proposal.edit.why") %>
   </p>
 
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
+    <% if @is_comment %>
+    <%= t("mailers.proposal.edit.why.you_are_commenter") %>
+    <% else %>
+    <%= t("mailers.proposal.edit.why.you_are_supporter") %>
+    <% end %>
+  </p>
+
+  <% if ! @is_comment %>
+  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
     <%= t("mailers.proposal.edit.do_you_disagree") %>
   </p>
+  <% end %>
 
   <%= link_to @proposal.title, proposal_url(@proposal), style: "font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;" %>
 

--- a/app/views/proposal_mailer/edit.html.erb
+++ b/app/views/proposal_mailer/edit.html.erb
@@ -1,20 +1,23 @@
 <td style="padding-bottom: 20px; padding-left: 10px;">
 
   <h1 style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;">
-    <%= t("mailers.comment.title") %>
+    <%= t("mailers.proposal.edit.title") %>
   </h1>
 
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
-    <%= t("mailers.comment.hi") %> <strong><%= @commentable.author.name %></strong>,
+    <%= t("mailers.proposal.hi") %> <strong><%= @voter.name %></strong>,
   </p>
 
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
-    <%= t("mailers.comment.new_comment_by_html", commenter: @comment.author.name) %> <%= link_to @commentable.title, commentable_url(@commentable), style: "color: #2895F1; text-decoration:none;" %>
+    <%= t("mailers.proposal.edit.introduction", title: @proposal.title) %>
+    <%= t("mailers.proposal.edit.why") %>
   </p>
 
-  <p style="border-left: 2px solid #DEE0E3;font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-style: italic;font-weight: normal;line-height: 24px;margin-left: 20px;padding: 10px;">
-    <%= text_with_links @comment.body %>
+  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
+    <%= t("mailers.proposal.edit.do_you_disagree") %>
   </p>
+
+  <%= link_to @proposal.title, proposal_url(@proposal), style: "font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;" %>
 
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 12px;font-weight: normal;line-height: 20px;">
     <%= t("mailers.config.manage_email_subscriptions") %> <%= link_to t("account.show.title"), account_url, style: "color: #2895F1; text-decoration:none;" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,8 @@ en:
       change_credentials_link: Change my password
       email_on_comment_label: Notify me by email when someone comments on my proposals
       email_on_comment_reply_label: Notify me by email when someone replies to my comments
+      email_on_proposal_edit_label: Notify me by email when someone edits a proposal I have supported
+      email_on_proposal_edit_as_commenter_label: Notify me by email when a proposal I have commented on is edited
       erase_account_link: Erase my account
       finish_verification: Complete verification
       notifications: Notifications
@@ -225,6 +227,7 @@ en:
       comments_on:
         one: Someone commented on
         other: There are %{count} new comments on
+      edited: The proposer edited
       empty_notifications: You don't have new notifications.
       mark_all_as_read: Mark all as read
       proposal_notification:

--- a/config/locales/mailers.en.yml
+++ b/config/locales/mailers.en.yml
@@ -14,7 +14,9 @@ en:
       edit:
         title: Proposal changed
         introduction: The proposer of %{title} has edited their proposal on MxV.
-        why: We're letting you know because you are a supporter of this proposal.
+        why:
+          you_are_supporter: We're letting you know because you are a supporter of this proposal.
+          you_are_commenter: We're letting you know because you commented on this proposal.
         do_you_disagree: 'You can see the changes, make comments and undo your support if you disagree here:'
     email_verification:
       click_here_to_verify: this link

--- a/config/locales/mailers.en.yml
+++ b/config/locales/mailers.en.yml
@@ -9,6 +9,13 @@ en:
       title: New comment
     config:
       manage_email_subscriptions: To stop receiving these emails change your settings in
+    proposal:
+      hi: Hi
+      edit:
+        title: Proposal changed
+        introduction: The proposer of %{title} has edited their proposal on MxV.
+        why: We're letting you know because you are a supporter of this proposal.
+        do_you_disagree: 'You can see the changes, make comments and undo your support if you disagree here:'
     email_verification:
       click_here_to_verify: this link
       instructions_2_html: This email will verify your account with <b>%{document_type} %{document_number}</b>. If these don't belong to you, please don't click on the previous link and ignore this email.

--- a/db/migrate/20161212171249_add_columns_for_new_emails.rb
+++ b/db/migrate/20161212171249_add_columns_for_new_emails.rb
@@ -1,0 +1,11 @@
+class AddColumnsForNewEmails < ActiveRecord::Migration
+  def up
+    add_column :users, :email_on_proposal_edit, :boolean, default: true
+    add_column :users, :email_on_proposal_edit_as_commenter, :boolean, default: true
+  end
+
+  def down
+    remove_column :users, :email_on_proposal_edit
+    remove_column :user, :email_on_proposal_edit_as_commenter
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161207171953) do
+ActiveRecord::Schema.define(version: 20161212171249) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -412,30 +412,30 @@ ActiveRecord::Schema.define(version: 20161207171953) do
   add_index "tolk_translations", ["phrase_id", "locale_id"], name: "index_tolk_translations_on_phrase_id_and_locale_id", unique: true, using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                                     default: ""
-    t.string   "encrypted_password",                        default: "",    null: false
+    t.string   "email",                                          default: ""
+    t.string   "encrypted_password",                             default: "",    null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",                             default: 0,     null: false
+    t.integer  "sign_in_count",                                  default: 0,     null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
     t.string   "last_sign_in_ip"
-    t.datetime "created_at",                                                null: false
-    t.datetime "updated_at",                                                null: false
+    t.datetime "created_at",                                                     null: false
+    t.datetime "updated_at",                                                     null: false
     t.string   "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string   "unconfirmed_email"
-    t.boolean  "email_on_comment",                          default: false
-    t.boolean  "email_on_comment_reply",                    default: false
-    t.string   "phone_number",                   limit: 30
+    t.boolean  "email_on_comment",                               default: true
+    t.boolean  "email_on_comment_reply",                         default: true
+    t.string   "phone_number",                        limit: 30
     t.string   "official_position"
-    t.integer  "official_level",                            default: 0
+    t.integer  "official_level",                                 default: 0
     t.datetime "hidden_at"
     t.string   "sms_confirmation_code"
-    t.string   "username",                       limit: 60
+    t.string   "username",                            limit: 60
     t.string   "document_number"
     t.string   "document_type"
     t.datetime "residence_verified_at"
@@ -446,25 +446,27 @@ ActiveRecord::Schema.define(version: 20161207171953) do
     t.datetime "letter_requested_at"
     t.datetime "confirmed_hide_at"
     t.string   "letter_verification_code"
-    t.integer  "failed_census_calls_count",                 default: 0
+    t.integer  "failed_census_calls_count",                      default: 0
     t.datetime "level_two_verified_at"
     t.string   "erase_reason"
     t.datetime "erased_at"
-    t.boolean  "public_activity",                           default: true
-    t.boolean  "newsletter",                                default: true
-    t.integer  "notifications_count",                       default: 0
-    t.boolean  "registering_with_oauth",                    default: false
+    t.boolean  "public_activity",                                default: true
+    t.boolean  "newsletter",                                     default: true
+    t.integer  "notifications_count",                            default: 0
+    t.boolean  "registering_with_oauth",                         default: false
     t.string   "locale"
     t.string   "oauth_email"
     t.integer  "geozone_id"
     t.string   "redeemable_code"
-    t.string   "gender",                         limit: 10
+    t.string   "gender",                              limit: 10
     t.datetime "date_of_birth"
-    t.boolean  "email_on_proposal_notification",            default: true
-    t.boolean  "email_digest",                              default: true
-    t.boolean  "email_on_direct_message",                   default: true
-    t.boolean  "official_position_badge",                   default: false
+    t.boolean  "email_on_proposal_notification",                 default: true
+    t.boolean  "email_digest",                                   default: true
+    t.boolean  "email_on_direct_message",                        default: true
+    t.boolean  "official_position_badge",                        default: false
     t.datetime "password_changed_at"
+    t.boolean  "email_on_proposal_edit",                         default: true
+    t.boolean  "email_on_proposal_edit_as_commenter",            default: true
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree


### PR DESCRIPTION
This both adds a notification for users on editing a proposal and sends them an e-mail.

If you have commented on a proposal it sends you an email, with no notification as I felt it was a bit too noisy, though implementing this would be easy.

# Test Plan

I created several users and checked the notifications and e-mails on editing from various perspectives (I used `letter_opener` to check).

- User edits their own proposal
  - Expected: no notifications, no emails.
- User who edits and has supported their proposal
  - Expected: no notifications, no emails.
- User who edits and has commented on their proposal
  - Expected: no notifications, no emails.
- User who comments on a proposal that is edited
  - Expected: email, no notifications.
- User who comments and supports a proposal that is edited
  - Expected: one email, one notification regarding their support.
- User who supports a proposal that is edited
 - Expected: one email, one notification regarding their support.

Automated tests to follow when I repair the whole test suite.